### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OverScrollBouncy
-#####An Android library which supports overscroll bounce effect. 
+##### An Android library which supports overscroll bounce effect. 
 It uses spring mechanism for animating the scrollback. It currently supports ***RecyclerView*** with LinearLayoutManager.
 
 ## Demo


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
